### PR TITLE
[readme][s]: Improve README and add deployment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-DataHub frontend in node.js.
+## Table of contents
+- [Table of contents](#table-of-contents)
+- [Quick Start](#quick-start)
+  - [Env vars](#env-vars)
+- [Developers](#developers)
+  - [Analytics](#analytics)
+- [Deployment](#deployment)
+
+---
+
+DataHub frontend in Node.js.
 
 [![Build Status](https://travis-ci.org/datopian/frontend.svg?branch=master)](https://travis-ci.org/datahq/frontend)
 
@@ -14,14 +24,15 @@ npm start
 
 ### Env vars
 
-We use `.env` file for loading environment variables. Please, use provided `env.template` as a template:
+We use `.env` file for loading environment variables. Please use the provided `env.template` as a template:
 
-* `SITE_URL` - FQ base URL of the site e.g. `https://datahub.io`
-* `API_URL` - FQ base URL of the API endpoint eg. `https://api.datahub.io`
+* `SITE_URL` - FQ base URL of the site, e.g. `https://datahub.io`
+* `API_URL` - FQ base URL of the API endpoint, e.g. `https://api.datahub.io`
 * `BITSTORE_URL` - base URL for the bitstore (pkgstore) e.g. `https://pkgstore.datahub.io`
 
 When running locally, use test api address in `.env`:
-```
+
+```bash
 API_URL=https://api-testing.datahub.io
 BITSTORE_URL=https://pkgstore-testing.datahub.io
 ```
@@ -30,9 +41,10 @@ See the [docs](http://docs.datahub.io/developers/) for more information.
 
 ## Developers
 
-The javascript portion of the app, which is responsible for rendering views,
+The JavaScript portion of the app, which is responsible for rendering views,
  comes from a different repo. That repo must be submoduled in and then built:
-```
+
+```bash
 git submodule init && git submodule update
 ```
 
@@ -44,7 +56,8 @@ To build the CSS:
    `sass --watch public/sass:public/stylesheets`
 
 Now run the server:
-```
+
+```bash
 export API_URL=https://api.datahub.io
 export BITSTORE_URL=https://pkgstore.datahub.io
 export dev=true
@@ -52,8 +65,9 @@ npm start
 ```
 
 To run in watch mode:
+
 ```bash
-# note the -e which means we watch for changes in templates too
+# Note the -e which means we watch for changes in templates too
 nodemon -e "js html" index.js
 ```
 
@@ -66,3 +80,10 @@ yarn test
 ### Analytics
 
 We use Google Tag Manager to manage all tags (eg, google analytics, optimize and more) so instead of adding a new script into templates, you should consider editing via UI of Tag Manager.
+
+## Deployment
+
+1. When pushing any commit to the `master` branch, it triggers a build on [the Deploy repo](https://github.com/datopian/deploy/pulls) which then creates a pull request there.
+2. The changes in frontend are auto deployed to the staging site of DataHub, located at https://testing.datahub.io.
+3. Once the staging site looks as expected, deployment to production happens by merging the automatically created pull request from step 1.
+4. That's it! Just wait for about 5 minutes and you should be able to see the changes reflected on DataHub.io.


### PR DESCRIPTION
This brings some changes to the README. @anuveyatsu was kind enough to guide me and explain how the deployment process works. This is most certainly something that we want to document for others to see as it was not obvious to me at first how this was happening.

* Add "Deployment" section for other Datopians.
* Add table of contents for easier navigation.
* Fix some typos/punctuation issues.
* Add language to fenced code blocks for syntax highlighting.